### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Curveball Redis Session Middleware
 ==================================
 
-This package adds support for sessions to the [Curveball][1] framework. The
+This package adds support for sessions to the [Curveball](1) framework. The
 session store is backed by Redis, therefore having an accessable Redis server
 is a prerequisite.
 


### PR DESCRIPTION
Fixing links. Not sure why the old link style [text][link] is not converting, but [text](link) seems to do the trick.