### PR TITLE
Adding @types/redis to the main dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -203,14 +203,12 @@
     "@types/node": {
       "version": "11.13.12",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.12.tgz",
-      "integrity": "sha512-HMD9cEGP+k2Y1Lk8LL6Cux9UlxkWst1wJdoMHnvH3XlVecHdjffW829/YzWd/ptFkIWtcbqQDrTkz5PY6pN+0w==",
-      "dev": true
+      "integrity": "sha512-HMD9cEGP+k2Y1Lk8LL6Cux9UlxkWst1wJdoMHnvH3XlVecHdjffW829/YzWd/ptFkIWtcbqQDrTkz5PY6pN+0w=="
     },
     "@types/redis": {
       "version": "2.8.13",
       "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.13.tgz",
       "integrity": "sha512-p86cm5P6DMotUqCS6odQRz0JJwc5QXZw9eyH0ALVIqmq12yqtex5ighWyGFHKxak9vaA/GF/Ilu0KZ0MuXXUbg==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@types/cookie": "^0.3.2",
     "@types/mocha": "^5.2.6",
     "@types/node": "^11.12.0",
-    "@types/redis": "^2.8.13",
     "@types/sinon": "^7.0.10",
     "chai": "^4.2.0",
     "mocha": "^6.0.2",
@@ -59,6 +58,7 @@
   "dependencies": {
     "@curveball/core": "^0.8.1",
     "@curveball/session": "^0.3.2",
+    "@types/redis": "^2.8.13",
     "cookie": "^0.3.1",
     "redis": "^2.8.0"
   }


### PR DESCRIPTION
### Changes
Moving the `@types/redis` package to the main dependencies so that they are included when the package is added to other projects