### PR TITLE
Improvement, adding prefix support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@curveball/session-redis",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curveball/session-redis",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Session storage backed by Redis using HTTP cookies",
   "main": "dist/index.js",
   "scripts": {

--- a/src/RedisStore.ts
+++ b/src/RedisStore.ts
@@ -3,6 +3,11 @@ import crypto from 'crypto';
 import redis, { ClientOpts, RedisClient } from 'redis';
 import { promisify } from 'util';
 
+type RedisOpts = {
+  clientOptions: ClientOpts,
+  prefix: string,
+};
+
 /**
  * The Redis session store keeps sessions in a Redis key-value cache store. The
  * store only uses basic Redis types.
@@ -13,10 +18,15 @@ import { promisify } from 'util';
 export default class RedisStore implements SessionStore {
 
   client: RedisClient;
+  opts: RedisOpts;
 
-  constructor(options?: ClientOpts) {
+  constructor(opts?: RedisOpts) {
+    const options = Object.assign({}, {
+      clientOptions: {},
+      prefix: 'session',
+    }, opts);
 
-    this.client = redis.createClient(options);
+    this.client = redis.createClient(options.clientOptions || {});
 
   }
 


### PR DESCRIPTION
### Changes
Updated the constructor to take a new RedisOpts type which only has two values right now, the ClientOpts for the redis package and a prefix string to use for getting, setting, and deleting in conjunction with the id/key that is provided.

Since this is a breaking change, I bumped the minor version, so this is now v0.2.0. :grin: 