### PR TITLE
Fixing README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ import { RedisStore } from '@curveball/session-redis';
 app.use(session({
   store: new RedisStore({
     prefix: 'mysess',
-    clientOpts: {
+    clientOptions: {
       host: 'myhost.redis',
       port: 1234,
       ...
@@ -49,7 +49,7 @@ app.use(session({
 });
 ```
 
-clientOpts is the set of options for the Redis client. The list of available
-clientOpts can be found on the [NodeRedis/node_redis](https://github.com/NodeRedis/node_redis#options-object-properties)
+clientOptions is the set of options for the Redis client. The list of available
+clientOptions can be found on the [NodeRedis/node_redis](https://github.com/NodeRedis/node_redis#options-object-properties)
 repository.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@curveball/session-redis",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curveball/session-redis",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Session storage backed by Redis using HTTP cookies",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
### Changes
`clientOpts` was used in the `README.md` file instead of the proper, `clientOptions`. Remedying that