### PR TITLE
 New feature: allow users to pass pre-existing Redis client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Here is another example with more options:
 
 ```typescript
 import session from '@curveball/session';
-import { RedisStore } from '@curveball/session-redis';
+import RedisStore from '@curveball/session-redis';
 
 app.use(session({
   store: new RedisStore({
@@ -51,7 +51,32 @@ app.use(session({
 });
 ```
 
-clientOptions is the set of options for the Redis client. The list of available
-clientOptions can be found on the [NodeRedis/node_redis](https://github.com/NodeRedis/node_redis#options-object-properties)
+`clientOptions` is the set of options for the Redis client. The list of
+available `clientOptions` can be found on the [NodeRedis/node_redis][1]
 repository.
 
+Instead of passing `clientOptions`, it's also possible to pass a fully setup
+isntance of RedisClient. This can be useful if the same connection should be
+re-used by a different part of your application:
+
+```typescript
+import session from '@curveball/session';
+import RedisStore from '@curveball/session-redis';
+import { RedisClient } from 'redis';
+
+const redis = new RedisClient({
+  host: 'myhost.redis',
+  port: 1234,
+});
+
+app.use(session({
+  store: new RedisStore({
+    prefix: 'mysess',
+    client: redis
+  })
+  cookieName: 'MY_SESSION',
+  expiry: 7200
+});
+```
+
+[1]: https://github.com/NodeRedis/node_redis#options-object-properties

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,35 @@
-0.0.1 (2018-??-??)
-==================
+Changelog
+=========
 
-* First version
+0.3.0 (2019-09-10)
+------------------
+
+* New feature: allow fully instantiated Redis client to be passed, instead of
+  letting the client connect by itself.
+
+
+0.2.2 (2019-06-05)
+------------------
+
+* Fixed bugs in readme.
+
+0.2.1 (2019-06-05)
+------------------
+
+* Update readme with correct documentation.
+
+0.2.0 (2019-06-05)
+------------------
+
+* Add prefix support.
+
+0.1.1 (2019-05-31)
+------------------
+
+* Removed unused dependencies
+* Unittests
+
+0.1.0 (2019-05-29)
+------------------
+
+* First public version

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { default as RedisStore } from './RedisStore';
+export { default as RedisStore, default as default } from './redis-store';

--- a/src/redis-store.ts
+++ b/src/redis-store.ts
@@ -9,7 +9,7 @@ type RedisOpts = {
 } | {
   client: RedisClient
   prefix: string
-}
+};
 
 /**
  * The Redis session store keeps sessions in a Redis key-value cache store. The
@@ -31,7 +31,7 @@ export default class RedisStore implements SessionStore {
 
     if ('client' in this.opts) {
       this.client = this.opts.client;
-    } else { 
+    } else {
       this.client = redis.createClient(this.opts.clientOptions);
     }
   }

--- a/src/redis-store.ts
+++ b/src/redis-store.ts
@@ -6,7 +6,10 @@ import { promisify } from 'util';
 type RedisOpts = {
   clientOptions: ClientOpts,
   prefix: string,
-};
+} | {
+  client: RedisClient
+  prefix: string
+}
 
 /**
  * The Redis session store keeps sessions in a Redis key-value cache store. The
@@ -26,7 +29,11 @@ export default class RedisStore implements SessionStore {
       prefix: 'session',
     }, opts);
 
-    this.client = redis.createClient(this.opts.clientOptions);
+    if ('client' in this.opts) {
+      this.client = this.opts.client;
+    } else { 
+      this.client = redis.createClient(this.opts.clientOptions);
+    }
   }
 
   async set(id: string, values: SessionValues, expire: number): Promise<void> {


### PR DESCRIPTION
This allows the same connection to be used by different parts of the
app.